### PR TITLE
ci: add standardized micromamba-based CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  EARTHENGINE_TOKEN: ${{ secrets.EARTHENGINE_TOKEN }}
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: sepal_environment.yml
+          cache-environment: true
+
+      - name: Install test deps
+        shell: micromamba-shell {0}
+        run: pip install pytest nbmake ipykernel
+
+      - name: Register kernel
+        shell: micromamba-shell {0}
+        run: python -m ipykernel install --user --name=test-kernel
+
+      - name: Test UI notebook
+        shell: micromamba-shell {0}
+        run: pytest --nbmake ui.ipynb --nbmake-timeout=600 --nbmake-kernel=test-kernel

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ dmypy.json
 test/
 outputs/
 utils/model2.h5
+CLAUDE.md


### PR DESCRIPTION
## Summary
- Replace existing CI with micromamba-based workflow that mirrors SEPAL platform deployment
- Create env from `sepal_environment.yml` (same as production) instead of installing sepal_ui from git
- Test UI notebook execution with pytest/nbmake

## Test plan
- [x] CI workflow runs successfully on this PR
- [x] Environment resolves from sepal_environment.yml
- [x] ui.ipynb executes without errors